### PR TITLE
Update Docker image deployment parameters

### DIFF
--- a/.github/workflows/publish-dev-docker-image.yml
+++ b/.github/workflows/publish-dev-docker-image.yml
@@ -60,13 +60,13 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: develop, latest
+          tags: develop
 
       - name: Build Docker Image
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: ${{ github.ref_type == 'tag' }}
+          push: true
           file: .github/dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This commit changes the tagging structure and push strategy for Docker images in the GitHub actions workflow. The 'latest' tag has been removed to ensure distinct separation between different stages of development. The push parameter is set to true to ensure Docker image is always pushed after build, increasing reliability in a continuous deployment pipeline.