### PR TITLE
Updated Fiware ID generation and device ID prefixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>de.app.5gla</groupId>
             <artifactId>fiware-integration-layer</artifactId>
-            <version>6.2.0</version>
+            <version>6.4.0</version>
             <exclusions>
                 <!-- SLF4J NOP -->
                 <exclusion>

--- a/src/main/java/de/app/fivegla/api/FiwareDevicMeasurementeId.java
+++ b/src/main/java/de/app/fivegla/api/FiwareDevicMeasurementeId.java
@@ -1,8 +1,7 @@
 package de.app.fivegla.api;
 
 import de.app.fivegla.config.manufacturer.CommonManufacturerConfiguration;
-
-import java.util.UUID;
+import de.app.fivegla.fiware.api.FiwareIdGenerator;
 
 /**
  * Generates FIWARE device measurement IDs.
@@ -16,7 +15,7 @@ public class FiwareDevicMeasurementeId {
      * @return The FIWARE device measurement ID.
      */
     public static String create(CommonManufacturerConfiguration commonManufacturerConfiguration) {
-        return create(commonManufacturerConfiguration, UUID.randomUUID().toString());
+        return create(commonManufacturerConfiguration, "");
     }
 
     /**
@@ -27,7 +26,7 @@ public class FiwareDevicMeasurementeId {
      * @return The FIWARE device measurement ID.
      */
     public static String create(CommonManufacturerConfiguration commonManufacturerConfiguration, String id) {
-        return commonManufacturerConfiguration.fiwareDeviceMeasurementIdPrefix() + id;
+        return FiwareIdGenerator.id(commonManufacturerConfiguration.fiwareDeviceIdPrefix() + id);
     }
 
 

--- a/src/main/java/de/app/fivegla/api/FiwareDeviceId.java
+++ b/src/main/java/de/app/fivegla/api/FiwareDeviceId.java
@@ -1,8 +1,7 @@
 package de.app.fivegla.api;
 
 import de.app.fivegla.config.manufacturer.CommonManufacturerConfiguration;
-
-import java.util.UUID;
+import de.app.fivegla.fiware.api.FiwareIdGenerator;
 
 /**
  * Generates FIWARE device IDs.
@@ -16,7 +15,7 @@ public class FiwareDeviceId {
      * @return The FIWARE device ID.
      */
     public static String create(CommonManufacturerConfiguration manufacturerConfiguration) {
-        return create(manufacturerConfiguration, UUID.randomUUID().toString());
+        return create(manufacturerConfiguration, "");
     }
 
     /**
@@ -27,7 +26,7 @@ public class FiwareDeviceId {
      * @return The FIWARE device ID.
      */
     public static String create(CommonManufacturerConfiguration commonManufacturerConfiguration, String id) {
-        return commonManufacturerConfiguration.fiwareDeviceIdPrefix() + id;
+        return FiwareIdGenerator.id(commonManufacturerConfiguration.fiwareDeviceIdPrefix() + id);
     }
 
 

--- a/src/main/java/de/app/fivegla/integration/micasense/MicaSenseIntegrationService.java
+++ b/src/main/java/de/app/fivegla/integration/micasense/MicaSenseIntegrationService.java
@@ -1,5 +1,6 @@
 package de.app.fivegla.integration.micasense;
 
+import de.app.fivegla.fiware.api.FiwareIdGenerator;
 import de.app.fivegla.integration.micasense.events.ImageProcessingFinishedEvent;
 import de.app.fivegla.integration.micasense.model.MicaSenseChannel;
 import de.app.fivegla.integration.micasense.model.MicaSenseImage;
@@ -12,7 +13,6 @@ import org.springframework.stereotype.Service;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -54,7 +54,7 @@ public class MicaSenseIntegrationService {
         log.debug("Channel for the image: {}.", micaSenseChannel);
         log.debug("Location for the image: {}.", location.getCoordinates());
         var micaSenseImage = applicationDataRepository.addMicaSenseImage(MicaSenseImage.builder()
-                .oid(UUID.randomUUID().toString())
+                .oid(FiwareIdGenerator.id())
                 .channel(micaSenseChannel)
                 .droneId(droneId)
                 .transactionId(transactionId)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,8 +4,8 @@ app:
   sensors:
     farm21:
       manufacturer: FARM21
-      fiwareDeviceIdPrefix: "urn:5gla:iotdevice:farm21:"
-      fiwareDeviceMeasurementIdPrefix: "urn:5gla:sensordata:farm21:"
+      fiwareDeviceIdPrefix: "urn:5gla:dev:f21:"
+      fiwareDeviceMeasurementIdPrefix: "urn:5gla:data:f21:"
       enabled: true
       url: https://app.farm21.tech/api/v2/public
       username: ${FARM21_USERNAME}
@@ -13,53 +13,53 @@ app:
       apiToken: ${FARM21_API_TOKEN}
     soilscout:
       manufacturer: SOIL_SCOUT
-      fiwareDeviceIdPrefix: "urn:5gla:iotdevice:soilscout:"
-      fiwareDeviceMeasurementIdPrefix: "urn:5gla:sensordata:soilscout:"
+      fiwareDeviceIdPrefix: "urn:5gla:dev:sosc:"
+      fiwareDeviceMeasurementIdPrefix: "urn:5gla:data:sosc:"
       enabled: true
       url: https://soilscouts.fi/api/v1
       username: ${SOILSCOUT_USERNAME}
       password: ${SOILSCOUT_PASSWORD}
     agranimo:
       manufacturer: AGRANIMO
-      fiwareDeviceIdPrefix: "urn:5gla:iotdevice:agranimo:"
-      fiwareDeviceMeasurementIdPrefix: "urn:5gla:sensordata:agranimo:"
+      fiwareDeviceIdPrefix: "urn:5gla:dev:agr:"
+      fiwareDeviceMeasurementIdPrefix: "urn:5gla:data:agr:"
       enabled: true
       url: https://public-staging.agranimo.com
       username: ${AGRANIMO_USERNAME}
       password: ${AGRANIMO_PASSWORD}
     agvolution:
       manufacturer: AGVOLUTION
-      fiwareDeviceIdPrefix: "urn:5gla:iotdevice:agvolution:"
-      fiwareDeviceMeasurementIdPrefix: "urn:5gla:sensordata:agvolution:"
+      fiwareDeviceIdPrefix: "urn:5gla:dev:agv:"
+      fiwareDeviceMeasurementIdPrefix: "urn:5gla:data:agv:"
       enabled: true
       url: https://api.agvolution.com
       username: ${AGVOLUTION_USERNAME}
       password: ${AGVOLUTION_PASSWORD}
     sensoterra:
       manufacturer: SENSOTERRA
-      fiwareDeviceIdPrefix: "urn:5gla:iotdevice:sensoterra:"
-      fiwareDeviceMeasurementIdPrefix: "urn:5gla:sensordata:sensoterra:"
+      fiwareDeviceIdPrefix: "urn:5gla:dev:st:"
+      fiwareDeviceMeasurementIdPrefix: "urn:5gla:data:st:"
       enabled: true
       url: https://monitor.sensoterra.com/api/v3
       username: ${SENSOTERRA_USERNAME}
       password: ${SENSOTERRA_PASSWORD}
     micasense:
       manufacturer: MICASENSE
-      fiwareDeviceIdPrefix: "urn:5gla:iotdevice:micasense:"
-      fiwareDeviceMeasurementIdPrefix: "urn:5gla:sensordata:micasense:"
+      fiwareDeviceIdPrefix: "urn:5gla:dev:ms:"
+      fiwareDeviceMeasurementIdPrefix: "urn:5gla:data:ms:"
       enabled: true
       imagePathBaseUrl: ${IMAGE_PATH_BASE_URL}
     sentek:
       manufacturer: SENTEK
-      fiwareDeviceIdPrefix: "urn:5gla:iotdevice:sentek:"
-      fiwareDeviceMeasurementIdPrefix: "urn:5gla:sensordata:sentek:"
+      fiwareDeviceIdPrefix: "urn:5gla:dev:sent:"
+      fiwareDeviceMeasurementIdPrefix: "urn:5gla:data:sent:"
       enabled: true
       url: https://www.irrimaxlive.com/api
       apiToken: ${SENTEK_API_TOKEN}
     weenat:
       manufacturer: WEENAT
-      fiwareDeviceIdPrefix: "urn:5gla:iotdevice:weenat:"
-      fiwareDeviceMeasurementIdPrefix: "urn:5gla:sensordata:weenat:"
+      fiwareDeviceIdPrefix: "urn:5gla:dev:wee:"
+      fiwareDeviceMeasurementIdPrefix: "urn:5gla:data:wee:"
       enabled: true
       url: https://api-prod.weenat.com/api
       username: ${WEENAT_USERNAME}


### PR DESCRIPTION
This commit updates the ID generation methodology for FIWARE device ID and measurement ID, moving away from UUIDs and now leveraging FiwareIdGenerator. Additionally, the prefixes of device IDs for different manufacturers in application.yml have been shortened to increase readability. This change will provide a more consistent result and improve clarity when interpreting these IDs in other systems.

Closes #109 