### PR TITLE
Update Fiware Integration Layer to version 10.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>de.app.5gla</groupId>
             <artifactId>fiware-integration-layer</artifactId>
-            <version>10.1.0</version>
+            <version>10.2.0</version>
             <exclusions>
                 <!-- SLF4J NOP -->
                 <exclusion>


### PR DESCRIPTION
The pom.xml file has been updated to use version 10.2.0 of the Fiware Integration Layer dependency. This update aims to enhance code consistency, reduce errors, and improve manageability by using the FiwareMetadataTypes enum instead of hardcoded strings.