### PR TITLE
Upgrade fiware-integration-layer version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>de.app.5gla</groupId>
             <artifactId>fiware-integration-layer</artifactId>
-            <version>10.6.0</version>
+            <version>10.7.0</version>
             <exclusions>
                 <!-- SLF4J NOP -->
                 <exclusion>


### PR DESCRIPTION
The version of fiware-integration-layer dependency in the pom.xml file has been updated from 10.6.0 to 10.7.0. This update ensures that the latest features, bug fixes, and patches of the library are incorporated into the code base.