### PR TITLE
Update fiware-integration-layer version to 12.2.0 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>de.app.5gla</groupId>
             <artifactId>fiware-integration-layer</artifactId>
-            <version>12.1.0</version>
+            <version>12.2.0</version>
             <exclusions>
                 <!-- SLF4J NOP -->
                 <exclusion>


### PR DESCRIPTION
The updated version 12.2.0 replaces the previous version 12.1.0 in the fiware-integration-layer dependency. This change is required to align with recent modifications for the Weenat integration service on device data persistency and to validate the service functionality with the most recent dependencies.