### PR TITLE
Umstellung der Parameter für die Nutzung von `key` anstelle der Namen der Entitätstypen

### DIFF
--- a/src/main/java/de/app/fivegla/event/ApplicationStartEventHandler.java
+++ b/src/main/java/de/app/fivegla/event/ApplicationStartEventHandler.java
@@ -14,8 +14,6 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -41,7 +39,7 @@ public class ApplicationStartEventHandler {
         var subscriptionService = subscriptionService(tenantId);
         if (subscriptionStatus.sendOutSubscriptions(tenantId)) {
             try {
-                subscriptionService.subscribe(Arrays.stream(MeasurementType.values()).map(Enum::name).toArray(String[]::new));
+                subscriptionService.subscribe(MeasurementType.values());
                 log.info("Subscribed to device measurement notifications.");
                 subscriptionStatus.subscriptionSent(tenantId);
             } catch (FiwareIntegrationLayerException e) {

--- a/src/main/java/de/app/fivegla/event/DataImportEventHandler.java
+++ b/src/main/java/de/app/fivegla/event/DataImportEventHandler.java
@@ -19,8 +19,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
-
 /**
  * Event handler for data import events.
  */
@@ -53,7 +51,7 @@ public class DataImportEventHandler {
             var config = dataImportEvent.thirdPartyApiConfiguration();
             if (subscriptionStatus.sendOutSubscriptions(tenantId)) {
                 try {
-                    subscriptionService(tenantId).subscribe(Arrays.stream(MeasurementType.values()).map(Enum::name).toArray(String[]::new));
+                    subscriptionService(tenantId).subscribe(MeasurementType.values());
                     log.info("Subscribed to device measurement notifications.");
                     subscriptionStatus.subscriptionSent(tenantId);
                 } catch (FiwareIntegrationLayerException e) {


### PR DESCRIPTION
The previous implementation of SubscriptionService used Strings to represent different types of measurements. This has now been refactored to use the MeasurementType enum, enhancing code readability and type safety. Changes were also made in ApplicationStartEventHandler and DataImportEventHandler to align with the update.