### PR TITLE
Update `runAllImports` method to handle all content types

### DIFF
--- a/src/main/java/de/app/fivegla/controller/global/MaintenanceController.java
+++ b/src/main/java/de/app/fivegla/controller/global/MaintenanceController.java
@@ -49,7 +49,7 @@ public class MaintenanceController implements ApiKeyApiAccess {
                     schema = @Schema(implementation = Response.class)
             )
     )
-    @PostMapping(value = "/run", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/run", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<? extends Response> runAllImports() {
         dataImportScheduler.scheduleDataImport();
         return ResponseEntity.ok().body(new Response());


### PR DESCRIPTION
Removed the `consumes` attribute from the `@PostMapping` annotation in the `runAllImports` method. This will make the server more flexible by allowing it to handle requests of any content type, not just those with `APPLICATION_JSON_VALUE`.