### PR TITLE
Remove httpCustom in SubscriptionIntegrationService

### DIFF
--- a/src/main/java/de/app/fivegla/integration/fiware/SubscriptionIntegrationService.java
+++ b/src/main/java/de/app/fivegla/integration/fiware/SubscriptionIntegrationService.java
@@ -93,9 +93,6 @@ public class SubscriptionIntegrationService extends AbstractIntegrationService {
                             .http(Http.builder()
                                     .url(notificationUrl)
                                     .build())
-                            .httpCustom(HttpCustom.builder()
-                                    .url(notificationUrl)
-                                    .build())
                             .build())
                     .build();
             subscriptions.add(subscription);


### PR DESCRIPTION
The httpCustom builder was redundant in the SubscriptionIntegrationService class, as it was duplicating the functionality of the http builder. The commit simplifies the construction by removing it. This makes the code cleaner and easy to maintain.