### PR TITLE
Add tenant deletion functionality

### DIFF
--- a/src/main/java/de/app/fivegla/business/TenantService.java
+++ b/src/main/java/de/app/fivegla/business/TenantService.java
@@ -123,6 +123,14 @@ public class TenantService implements UserDetailsService {
     }
 
     /**
+     * Deletes a tenant by its tenantId.
+     * @param tenantId The tenantId of the tenant to delete.
+     */
+    public void delete(String tenantId) {
+        tenantRepository.deleteTenant(tenantId);
+    }
+
+    /**
      * Represents a combination of Tenant object and an access token.
      */
     public record TenantAndAccessToken(Tenant tenant, String accessToken) {

--- a/src/main/java/de/app/fivegla/controller/global/TenantController.java
+++ b/src/main/java/de/app/fivegla/controller/global/TenantController.java
@@ -136,4 +136,31 @@ public class TenantController implements ApiKeyApiAccess {
         return ResponseEntity.ok(ReadTenantsResponse.builder().tenants(tenants).build());
     }
 
+    @Operation(
+            operationId = "tenant.delete",
+            description = "Delete a tenant based on the provided request.",
+            tags = BaseMappings.TENANT
+    )
+    @ApiResponse(
+            responseCode = "204",
+            description = "The tenant was deleted successfully.",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = Response.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "The request is invalid.",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = Response.class)
+            )
+    )
+    @DeleteMapping(value = "/{tenantId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<? extends Response> delete(@PathVariable String tenantId) {
+        tenantService.delete(tenantId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/de/app/fivegla/persistence/TenantRepository.java
+++ b/src/main/java/de/app/fivegla/persistence/TenantRepository.java
@@ -5,12 +5,14 @@ import de.app.fivegla.api.ErrorMessage;
 import de.app.fivegla.api.exceptions.BusinessException;
 import de.app.fivegla.persistence.entity.Tenant;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class TenantRepository {
@@ -84,5 +86,35 @@ public class TenantRepository {
      */
     public List<Tenant> findTenants() {
         return applicationData.getTenants();
+    }
+
+
+    /**
+     * Deletes a tenant with the specified tenant ID.
+     *
+     * @param tenantId The ID of the tenant to delete.
+     */
+    public void deleteTenant(String tenantId) {
+        if (null != applicationData.getTenants()) {
+            log.info("Deleting tenant with tenantId: {}", tenantId);
+            applicationData.setTenants(applicationData.getTenants().stream()
+                    .filter(t -> !t.getTenantId().equals(tenantId))
+                    .toList());
+            applicationData.persist();
+        }
+        if (null != applicationData.getGroups()) {
+            log.info("Deleting groups for tenant with tenantId: {}", tenantId);
+            applicationData.setGroups(applicationData.getGroups().stream()
+                    .filter(g -> !g.getTenant().getTenantId().equals(tenantId))
+                    .toList());
+            applicationData.persist();
+        }
+        if (null != applicationData.getThirdPartyApiConfigurations()) {
+            log.info("Deleting third party API configurations for tenant with tenantId: {}", tenantId);
+            applicationData.setThirdPartyApiConfigurations(applicationData.getThirdPartyApiConfigurations().stream()
+                    .filter(t -> !t.getTenantId().equals(tenantId))
+                    .toList());
+            applicationData.persist();
+        }
     }
 }


### PR DESCRIPTION
Added a deletion function to the TenantRepository, TenantService, and TenantController that allows tenants to be deleted by their tenant Id. This includes removing related groups and third-party API configurations for the deleted tenant.