### PR TITLE
Renamed 'group' to 'customGroup' in model classes

### DIFF
--- a/src/main/java/de/app/fivegla/integration/fiware/model/AgriCrop.java
+++ b/src/main/java/de/app/fivegla/integration/fiware/model/AgriCrop.java
@@ -27,7 +27,7 @@ public record AgriCrop(
         var json = "{" +
                 "  \"id\":\"" + id + "\"," +
                 "  \"type\":\"" + type + "\"," +
-                "  \"group\":" + group.asJson() + "," +
+                "  \"customGroup\":" + group.asJson() + "," +
                 "  \"dateCreated\":" + dateCreated.asJson() + "," +
                 "  \"coordinates\":" + coordinatesAsJson(coordinates) +
                 "}";

--- a/src/main/java/de/app/fivegla/integration/fiware/model/DeviceMeasurement.java
+++ b/src/main/java/de/app/fivegla/integration/fiware/model/DeviceMeasurement.java
@@ -28,7 +28,7 @@ public record DeviceMeasurement(
         var json = "{" +
                 "  \"id\":\"" + id + "\"," +
                 "  \"type\":\"" + type + "\"," +
-                "  \"group\":" + group.asJson() + "," +
+                "  \"customGroup\":" + group.asJson() + "," +
                 "  \"name\":" + name.asJson() + "," +
                 "  \"controlledProperty\":" + controlledProperty.asJson() + "," +
                 "  \"externalDataReference\":" + externalDataReference.asJson() + "," +

--- a/src/main/java/de/app/fivegla/integration/fiware/model/DevicePosition.java
+++ b/src/main/java/de/app/fivegla/integration/fiware/model/DevicePosition.java
@@ -27,7 +27,7 @@ public record DevicePosition(
         var json = "{" +
                 "  \"id\":\"" + id + "\"," +
                 "  \"type\":\"" + type + "\"," +
-                "  \"group\":" + group.asJson() + "," +
+                "  \"customGroup\":" + group.asJson() + "," +
                 "  \"transactionId\":" + transactionId.asJson() + "," +
                 "  \"deviceId\":" + deviceId.asJson() + "," +
                 "  \"dateCreated\":" + dateCreated.asJson() + "," +


### PR DESCRIPTION
The name of the attribute 'group' has been changed to 'customGroup' in the DevicePosition, DeviceMeasurement, and AgriCrop classes. This modification standardizes naming conventions across various model classes.