### PR TITLE
Implement pre-configured S3 bucket use for image uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,36 +8,6 @@ BMVI).The website of the project is https://www.5gla.de/, you can find all addit
 interested in the source code,you can find it on
 GitHub: https://github.com/vitrum-connect/5gla-sensor-integration-services
 
-## Run the application within the IDE
-
-To run the application you need to set multiple environment variables. The easiest way to do this is to use the
-following template and replace the values with your own ones:
-
-```
-  CONTEXT_BROKER_URL=https://localhost:1026/;
-  MICROSTREAM_STORAGE_DIRECTORY=/opt/application/.microstream;
-  IMAGE_PATH_BASE_URL=http://localhost:8080/api/images/;
-  API_KEY=___CHANGE_ME___;
-  NOTIFICATION_URLS=https://localhost:5050/notify;
-  SPRING_PROFILES_ACTIVE=maintenance;
-  CORS_ALLOWED_ORIGINS=http://localhost:8080;
-  CONTEXT_PATH=/api;
-```
-
-The following table describes the environment variables:
-
-| Environment Variable          | Description                                             |
-|-------------------------------|---------------------------------------------------------|
-| CONTEXT_BROKER_URL            | The URL of the Orion Context Broker.                    |
-| MICROSTREAM_STORAGE_DIRECTORY | The directory where the Microstream database is stored. |
-| IMAGE_PATH_BASE_URL           | The base URL of the image path.                         |
-| SENTEK_API_TOKEN              | The API token of the Sentek account.                    |
-| API_KEY                       | The API key of the application.                         |
-| NOTIFICATION_URLS             | The URL of the notification service.                    |
-| SPRING_PROFILES_ACTIVE        | The active Spring profile.                              |
-| CORS_ALLOWED_ORIGINS          | The allowed origins for CORS.                           |
-| CONTEXT_PATH                  | The context path of the application.                    |
-
 ## Build the project
 
 To build the project and to resolve the dependencies from GitHub Packages you need to create a personal access token and

--- a/src/main/java/de/app/fivegla/integration/fiware/model/DroneDeviceMeasurement.java
+++ b/src/main/java/de/app/fivegla/integration/fiware/model/DroneDeviceMeasurement.java
@@ -1,0 +1,65 @@
+package de.app.fivegla.integration.fiware.model;
+
+import de.app.fivegla.integration.fiware.model.api.FiwareEntity;
+import de.app.fivegla.integration.fiware.model.api.Validatable;
+import de.app.fivegla.integration.fiware.model.internal.Attribute;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Device measurement.
+ */
+@Slf4j
+public record DroneDeviceMeasurement(
+        String id,
+        String type,
+        Attribute group,
+        Attribute oid,
+        Attribute droneId,
+        Attribute transactionId,
+        Attribute imageChannel,
+        Attribute base64encodedImage,
+        Attribute imagePath,
+        double latitude,
+        double longitude
+) implements FiwareEntity, Validatable {
+
+    @Override
+    public String asJson() {
+        validate();
+        var json = "{" +
+                "  \"id\":\"" + id.trim() + "\"," +
+                "  \"type\":\"" + type.trim() + "\"," +
+                "  \"customGroup\":" + group.asJson().trim() + "," +
+                "  \"oid\":" + oid.asJson().trim() + "," +
+                "  \"droneId\":" + droneId.asJson().trim() + "," +
+                "  \"transactionId\":" + transactionId.asJson().trim() + "," +
+                "  \"imageChannel\":" + imageChannel.asJson().trim() + "," +
+                "  \"base64encodedImage\":" + base64encodedImage.asJson().trim() + "," +
+                "  \"imagePath\":" + imagePath.asJson().trim() + "," +
+                "  \"location\":" + locationAsJson(latitude, longitude).trim() +
+                "}";
+        log.debug("{} as JSON: {}", this.getClass().getSimpleName(), json);
+        return json;
+    }
+
+    @Override
+    public void validate() {
+        if (StringUtils.isBlank(id)) {
+            throw new IllegalArgumentException("The id of the device measurement must not be null or blank.");
+        }
+        if (StringUtils.isBlank(type)) {
+            throw new IllegalArgumentException("The type of the device measurement must not be null or blank.");
+        }
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+}

--- a/src/main/java/de/app/fivegla/integration/fiware/model/MicaSenseImage.java
+++ b/src/main/java/de/app/fivegla/integration/fiware/model/MicaSenseImage.java
@@ -10,7 +10,7 @@ import org.apache.commons.lang3.StringUtils;
  * Device measurement.
  */
 @Slf4j
-public record DroneDeviceMeasurement(
+public record MicaSenseImage(
         String id,
         String type,
         Attribute group,

--- a/src/main/java/de/app/fivegla/integration/fiware/model/MicaSenseImage.java
+++ b/src/main/java/de/app/fivegla/integration/fiware/model/MicaSenseImage.java
@@ -20,6 +20,7 @@ public record MicaSenseImage(
         Attribute imageChannel,
         Attribute base64encodedImage,
         Attribute imagePath,
+        Attribute dateCreated,
         double latitude,
         double longitude
 ) implements FiwareEntity, Validatable {
@@ -37,6 +38,7 @@ public record MicaSenseImage(
                 "  \"imageChannel\":" + imageChannel.asJson().trim() + "," +
                 "  \"base64encodedImage\":" + base64encodedImage.asJson().trim() + "," +
                 "  \"imagePath\":" + imagePath.asJson().trim() + "," +
+                "  \"dateCreated\":" + dateCreated.asJson().trim() + "," +
                 "  \"location\":" + locationAsJson(latitude, longitude).trim() +
                 "}";
         log.debug("{} as JSON: {}", this.getClass().getSimpleName(), json);

--- a/src/main/java/de/app/fivegla/integration/imageprocessing/ImageProcessingFiwareIntegrationServiceWrapper.java
+++ b/src/main/java/de/app/fivegla/integration/imageprocessing/ImageProcessingFiwareIntegrationServiceWrapper.java
@@ -3,7 +3,7 @@ package de.app.fivegla.integration.imageprocessing;
 
 import de.app.fivegla.api.enums.EntityType;
 import de.app.fivegla.integration.fiware.FiwareEntityIntegrationService;
-import de.app.fivegla.integration.fiware.model.DroneDeviceMeasurement;
+import de.app.fivegla.integration.fiware.model.MicaSenseImage;
 import de.app.fivegla.integration.fiware.model.internal.TextAttribute;
 import de.app.fivegla.persistence.entity.Group;
 import de.app.fivegla.persistence.entity.Image;
@@ -31,7 +31,7 @@ public class ImageProcessingFiwareIntegrationServiceWrapper {
      * @param image the image to create the measurement for
      */
     public void createDroneDeviceMeasurement(Tenant tenant, Group group, String droneId, Image image) {
-        var deviceMeasurement = new DroneDeviceMeasurement(
+        var deviceMeasurement = new MicaSenseImage(
                 tenant.getFiwarePrefix() + droneId,
                 EntityType.MICASENSE_IMAGE.getKey(),
                 new TextAttribute(group.getOid()),

--- a/src/main/java/de/app/fivegla/integration/imageprocessing/ImageProcessingFiwareIntegrationServiceWrapper.java
+++ b/src/main/java/de/app/fivegla/integration/imageprocessing/ImageProcessingFiwareIntegrationServiceWrapper.java
@@ -3,9 +3,7 @@ package de.app.fivegla.integration.imageprocessing;
 
 import de.app.fivegla.api.enums.EntityType;
 import de.app.fivegla.integration.fiware.FiwareEntityIntegrationService;
-import de.app.fivegla.integration.fiware.model.DeviceMeasurement;
-import de.app.fivegla.integration.fiware.model.internal.DateAttribute;
-import de.app.fivegla.integration.fiware.model.internal.EmptyAttribute;
+import de.app.fivegla.integration.fiware.model.DroneDeviceMeasurement;
 import de.app.fivegla.integration.fiware.model.internal.TextAttribute;
 import de.app.fivegla.persistence.entity.Group;
 import de.app.fivegla.persistence.entity.Image;
@@ -33,14 +31,16 @@ public class ImageProcessingFiwareIntegrationServiceWrapper {
      * @param image the image to create the measurement for
      */
     public void createDroneDeviceMeasurement(Tenant tenant, Group group, String droneId, Image image) {
-        var deviceMeasurement = new DeviceMeasurement(
+        var deviceMeasurement = new DroneDeviceMeasurement(
                 tenant.getFiwarePrefix() + droneId,
                 EntityType.MICASENSE_IMAGE.getKey(),
                 new TextAttribute(group.getOid()),
-                new TextAttribute("image"),
-                new EmptyAttribute(),
-                new DateAttribute(image.getMeasuredAt()),
-                new TextAttribute(imagePathBaseUrl + image.getOid()),
+                new TextAttribute(image.getOid()),
+                new TextAttribute(droneId),
+                new TextAttribute(image.getTransactionId()),
+                new TextAttribute(image.getChannel().name()),
+                new TextAttribute(image.getBase64encodedImage()),
+                new TextAttribute(imagePathBaseUrl + image.getFullFilename(tenant)),
                 image.getLatitude(),
                 image.getLongitude());
         fiwareEntityIntegrationService.persist(tenant, group, deviceMeasurement);

--- a/src/main/java/de/app/fivegla/integration/imageprocessing/ImageProcessingFiwareIntegrationServiceWrapper.java
+++ b/src/main/java/de/app/fivegla/integration/imageprocessing/ImageProcessingFiwareIntegrationServiceWrapper.java
@@ -41,6 +41,7 @@ public class ImageProcessingFiwareIntegrationServiceWrapper {
                 new TextAttribute(image.getChannel().name()),
                 new TextAttribute(image.getBase64encodedImage()),
                 new TextAttribute(imagePathBaseUrl + image.getFullFilename(tenant)),
+                new TextAttribute(image.getMeasuredAt().toString()),
                 image.getLatitude(),
                 image.getLongitude());
         fiwareEntityIntegrationService.persist(tenant, group, deviceMeasurement);

--- a/src/main/java/de/app/fivegla/integration/imageprocessing/PersistentStorageIntegrationService.java
+++ b/src/main/java/de/app/fivegla/integration/imageprocessing/PersistentStorageIntegrationService.java
@@ -27,6 +27,9 @@ public class PersistentStorageIntegrationService {
     @Value("${app.s3.secretKey}")
     private String secretKey;
 
+    @Value("${app.s3.preConfiguredBucketName}")
+    private String preConfiguredBucketName;
+
     /**
      * Stores an image on S3.
      *
@@ -37,17 +40,17 @@ public class PersistentStorageIntegrationService {
         try (var client = minioClientBuilder()
                 .build()) {
             if (!client.bucketExists(BucketExistsArgs.builder()
-                    .bucket(transactionId)
+                    .bucket(preConfiguredBucketName)
                     .build())) {
                 client.makeBucket(MakeBucketArgs.builder()
-                        .bucket(transactionId)
+                        .bucket(preConfiguredBucketName)
                         .build());
                 log.debug("Bucket {} created.", transactionId);
             }
             var imageAsRawData = image.getImageAsRawData();
             client.putObject(PutObjectArgs.builder()
-                    .bucket(transactionId)
-                    .object(image.getName())
+                    .bucket(preConfiguredBucketName)
+                    .object(image.getFullFilename(image.getTenant()))
                     .stream(new ByteArrayInputStream(imageAsRawData), imageAsRawData.length, -1)
                     .build());
         } catch (Exception e) {

--- a/src/main/java/de/app/fivegla/persistence/entity/Image.java
+++ b/src/main/java/de/app/fivegla/persistence/entity/Image.java
@@ -96,7 +96,7 @@ public class Image extends BaseEntity {
      *
      * @return the name of the image
      */
-    public String getName() {
-        return droneId + channel.name() + measuredAt.toInstant().getEpochSecond() + ".tiff";
+    public String getFullFilename(Tenant tenant) {
+        return tenant.getTenantId() + "/" + droneId + "/" + channel.name() + "/" + measuredAt.toInstant().getEpochSecond() + ".tiff";
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,7 @@ app:
     endpoint: ${S3_ENDPOINT}
     accessKey: ${S3_ACCESS_KEY}
     secretKey: ${S3_SECRET_KEY}
+    preConfiguredBucketName: ${S3_BUCKET_NAME}
 logging:
   level:
     root: info


### PR DESCRIPTION
The code has been updated to utilize a pre-configured S3 bucket for uploading images instead of creating a new bucket for each transaction. Additionally, changes were made to the Image class to include tenant information in the file name, providing a clearer organization of the stored images. A new configuration has also been added to the application.yml file for specifying the pre-configured S3 bucket name.