### PR TITLE
Add new changeSet to remove txid from stationary images

### DIFF
--- a/src/main/resources/db/changelog/V6__remove_txid_from_stationary_images.sql
+++ b/src/main/resources/db/changelog/V6__remove_txid_from_stationary_images.sql
@@ -1,0 +1,2 @@
+alter table stationary_image
+    drop column transaction_id;

--- a/src/main/resources/db/changelog/db.changelog-master.yml
+++ b/src/main/resources/db/changelog/db.changelog-master.yml
@@ -29,3 +29,9 @@ databaseChangeLog:
       changes:
         - sqlFile:
             path: db/changelog/V5__add_stationary_images.sql
+  - changeSet:
+      id: 6
+      author: Sascha Doemer | sascha.doemer@lmis.de
+      changes:
+        - sqlFile:
+            path: db/changelog/V6__remove_txid_from_stationary_images.sql


### PR DESCRIPTION
Introduced a new changeSet with ID 6, authored by Sascha Doemer, to execute SQL script for removing txid from stationary images. This is part of an ongoing database schema update.