### PR TITLE
Rename table to 'stationary_image'

### DIFF
--- a/src/main/java/de/app/fivegla/persistence/entity/StationaryImage.java
+++ b/src/main/java/de/app/fivegla/persistence/entity/StationaryImage.java
@@ -14,7 +14,7 @@ import java.util.Date;
 @Entity
 @Getter
 @Setter
-@Table(name = "image")
+@Table(name = "stationary_image")
 public class StationaryImage extends BaseEntity {
 
     /**


### PR DESCRIPTION
Renamed the table from 'image' to 'stationary_image' to better reflect the entity's purpose. This change aims to enhance clarity and maintain consistent naming conventions within the codebase.