### PR TITLE
Update schema for stationary images

### DIFF
--- a/src/main/resources/db/changelog/V7__adapt_internal_schema_for_stationary_images.sql
+++ b/src/main/resources/db/changelog/V7__adapt_internal_schema_for_stationary_images.sql
@@ -1,0 +1,3 @@
+-- noinspection SqlDeprecateTypeForFile
+alter table stationary_image
+    modify base64_encoded_image longtext not null;

--- a/src/main/resources/db/changelog/db.changelog-master.yml
+++ b/src/main/resources/db/changelog/db.changelog-master.yml
@@ -35,3 +35,9 @@ databaseChangeLog:
       changes:
         - sqlFile:
             path: db/changelog/V6__remove_txid_from_stationary_images.sql
+  - changeSet:
+      id: 7
+      author: Sascha Doemer | sascha.doemer@lmis.de
+      changes:
+        - sqlFile:
+            path: db/changelog/V7__adapt_internal_schema_for_stationary_images.sql


### PR DESCRIPTION
Add a new changelog script to modify the `base64_encoded_image` column to `longtext not null` in the `stationary_image` table. This change is reflected in the master changelog file.