### PR TITLE
Rename "coordinates" field to "location" in AgriCrop JSON.

### DIFF
--- a/src/main/java/de/app/fivegla/integration/fiware/api/FiwareType.java
+++ b/src/main/java/de/app/fivegla/integration/fiware/api/FiwareType.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 @Getter
 public enum FiwareType {
     GEO_JSON("geo:json"),
+    GEO_PROPERTY("GeoProperty"),
     DATE_TIME("DateTime"),
     TEXT("Text"),
     NUMBER("Number"),

--- a/src/main/java/de/app/fivegla/integration/fiware/api/FiwareType.java
+++ b/src/main/java/de/app/fivegla/integration/fiware/api/FiwareType.java
@@ -11,7 +11,6 @@ import lombok.Getter;
  */
 @Getter
 public enum FiwareType {
-    GEO_JSON("geo:json"),
     GEO_PROPERTY("GeoProperty"),
     DATE_TIME("DateTime"),
     TEXT("Text"),

--- a/src/main/java/de/app/fivegla/integration/fiware/model/AgriCrop.java
+++ b/src/main/java/de/app/fivegla/integration/fiware/model/AgriCrop.java
@@ -29,7 +29,7 @@ public record AgriCrop(
                 "  \"type\":\"" + type.trim() + "\"," +
                 "  \"customGroup\":" + group.asJson().trim() + "," +
                 "  \"dateCreated\":" + dateCreated.asJson().trim() + "," +
-                "  \"coordinates\":" + coordinatesAsJson(coordinates).trim() +
+                "  \"location\":" + coordinatesAsJson(coordinates).trim() +
                 "}";
         log.debug("{} as JSON: {}", this.getClass().getSimpleName(), json);
         return json;

--- a/src/main/java/de/app/fivegla/integration/fiware/model/api/FiwareEntity.java
+++ b/src/main/java/de/app/fivegla/integration/fiware/model/api/FiwareEntity.java
@@ -30,7 +30,7 @@ public interface FiwareEntity {
             return "{}";
         } else {
             return "{" +
-                    "  \"type\":\"" + FiwareType.GEO_JSON.getKey() + "\"," +
+                    "  \"type\":\"" + FiwareType.GEO_PROPERTY.getKey() + "\"," +
                     "  \"value\": {" +
                     "    \"type\":\"Point\"," +
                     "    \"coordinates\": [" + longitude + "," + latitude + "]" +

--- a/src/main/java/de/app/fivegla/integration/fiware/model/api/FiwareEntity.java
+++ b/src/main/java/de/app/fivegla/integration/fiware/model/api/FiwareEntity.java
@@ -50,7 +50,7 @@ public interface FiwareEntity {
             return "{}";
         } else {
             return "{" +
-                    "  \"type\":\"" + FiwareType.GEO_JSON.getKey() + "\"," +
+                    "  \"type\":\"" + FiwareType.GEO_PROPERTY.getKey() + "\"," +
                     "  \"value\": {" +
                     "    \"type\":\"Polygon\"," +
                     "    \"coordinates\": [" + coordinates.stream().map(c -> "[" + c.getLatitude() + "," + c.getLongitude() + "]").reduce((a, b) -> a + "," + b).orElse("") + "]" +


### PR DESCRIPTION
Updated the JSON serialization to reflect the rename of the "coordinates" field to "location" for consistency with expected schema naming. This change ensures better alignment with integration requirements.